### PR TITLE
fix: 토큰 관련 오류 해결

### DIFF
--- a/src/components/Header/TopMenu.tsx
+++ b/src/components/Header/TopMenu.tsx
@@ -3,8 +3,9 @@ import {useNavigate} from 'react-router-dom';
 import {useDispatch} from 'react-redux';
 import Cookies from 'js-cookie';
 import {baseAPI} from '@/apis/utils/instance';
-import {clearUserInfo} from '@/store/userSlice';
 import {useAppSelector} from '@/store/hooks';
+import {clearUserInfo} from '@/store/userSlice';
+import {deleteAll} from '@/store/modules/tabSlice';
 import Left from '@assets/img/btn_main_top_left.svg?react';
 import Right from '@assets/img/btn_main_top_right.svg?react';
 import logout from '@assets/img/logout.png';
@@ -21,6 +22,7 @@ function TopMenu() {
 
   const handleLogout = () => {
     dispatch(clearUserInfo());
+    dispatch(deleteAll());
     delete baseAPI.defaults.headers.common['Authorization'];
     Cookies.remove('accessToken');
     navigate('/login');

--- a/src/components/LectureList/index.tsx
+++ b/src/components/LectureList/index.tsx
@@ -32,7 +32,9 @@ function LectureList() {
   useEffect(() => {
     const getList = async () => {
       await getCourseList({}).then(res => {
-        setList(res);
+        if (res) {
+          setList(res);
+        }
       });
     };
 

--- a/src/components/LoginForm/index.tsx
+++ b/src/components/LoginForm/index.tsx
@@ -16,7 +16,6 @@ function LoginForm() {
   const [error, setError] = useState<string | null>(null);
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const expiration = new Date(Date.now() + 600 * 1000);
 
   const handleLogin = async () => {
     if (!id || !password) {
@@ -31,7 +30,7 @@ function LoginForm() {
       });
       console.log('Login successful');
 
-      Cookies.set('accessToken', response.accessToken, {expires: expiration});
+      Cookies.set('accessToken', response.accessToken, {expires: 0.5 / 24});
       baseAPI.defaults.headers.common['Authorization'] =
         `Bearer ${response.accessToken}`;
 


### PR DESCRIPTION
## Issue
- #38 
## Details
- 토큰 재발급 후 헤더의 토큰이 바뀌지 않는 오류를 수정했습니다.
- 요청 시 헤더에 토큰이 없을 경우 쿠키에서 토큰을 가져와서 요청하도록 수정했습니다.
- 쿠키에 토큰을 저장할 때 expires에 만료 날짜를 넣었었는데, 유효 시간(30분)으로 변경했습니다.
- 강의 목록 조회 시 응답이 undefined가 아닐 때에만 state를 업데이트하도록 수정했습니다.
- 로그아웃할 때 스토어에 저장했던 탭 데이터도 삭제되도록 했습니다.
