### PR TITLE
refactor(TS-14): 에러 핸들링 방식 변경

### DIFF
--- a/src/components/common/Modal/LoadingModal.tsx
+++ b/src/components/common/Modal/LoadingModal.tsx
@@ -60,7 +60,8 @@ function LoadingModal({
       // 수강신청 요청
       try {
         const res = await postCourse(scheduleId);
-        if (res === 'Course already registered') {
+
+        if (res.status === 409) {
           return;
         }
       } catch (error) {


### PR DESCRIPTION
## Issue
- [TS-14](https://jeez.atlassian.net/browse/TS-14?atlOrigin=eyJpIjoiNGY1YWVlOTdiNzY2NGE3YmE4NzJjZjMwODBjYTlmZmUiLCJwIjoiaiJ9)
## Details
- 지정된 에러 코드로 처리하도록 변경했습니다.
**에러 코드**
> S001 : 인증과정 중간 오류 발생, 존재하지 않는 강의
> S002 : access token 만료
> S003 : 유효하지 않은 토큰
> C001 : 중복 수강신청
> G001 : 서버 내부오류
> G005 : 접근 거부
> W001 : 중복 담기
> W002 : 수강신청된 과목 담기
> W003 : 존재하지 않는 과목 

- 쿠키에 저장된 리프레시 토큰의 유효 기간을 1일로 변경했습니다.
- api 통신 요청할 때 헤더에  토큰이 없는 경우 추가하는 코드를 수정했습니다.
- 중복으로 신청 했을 때에도 성공 모달이 뜨는 현상을 해결했습니다.

[TS-14]: https://jeez.atlassian.net/browse/TS-14?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ