### PR TITLE
feat(TS-47): 관심과목 기반 시간표 생성

### DIFF
--- a/src/components/Wishlist/index.tsx
+++ b/src/components/Wishlist/index.tsx
@@ -11,6 +11,8 @@ import {
 import {RootState} from '@/store/store';
 import {useSelector} from 'react-redux';
 import {TableTitle, TableTitleWrap} from '../LectureList';
+import {openModalHandler} from '../common/Modal/handlers/handler';
+import {useAppDispatch} from '@/store/hooks';
 
 const searchResultColData = [
   {name: 'action', value: '신청', initialWidth: 50, enableFilters: false},
@@ -44,6 +46,7 @@ function Wishlist() {
   const [registeredCourseCount, setRegisteredCourseCount] = useState(0);
   const [registeredCredits, setRegisteredCredits] = useState(0);
   const {username} = useSelector((state: RootState) => state.userInfo);
+  const dispatch = useAppDispatch();
 
   const fetchWishlist = useCallback(async () => {
     try {
@@ -95,6 +98,13 @@ function Wishlist() {
     }
   };
 
+  const handleClickTimetable = () => {
+    openModalHandler(dispatch, 'timetable');
+    if (wishlistData.length !== 0) {
+      document.body.style.overflow = 'hidden';
+    }
+  };
+
   return (
     <WishlistContainer>
       <Filters setSearchResults={setSearchResultsData} />
@@ -114,9 +124,9 @@ function Wishlist() {
       </WishlistInfo>
       <TableWrapper>
         <TableSection>
-          <TableTitleWrap>
+          <WishTitleWrap>
             <TableTitle>관심과목 대상교과목</TableTitle>
-          </TableTitleWrap>
+          </WishTitleWrap>
           <Table
             colData={searchResultColData}
             data={searchResultsData}
@@ -126,9 +136,10 @@ function Wishlist() {
           />
         </TableSection>
         <TableSection>
-          <TableTitleWrap>
+          <WishTitleWrap>
             <TableTitle>관심과목내역</TableTitle>
-          </TableTitleWrap>
+            <ButtonWrap onClick={handleClickTimetable}>예상시간표</ButtonWrap>
+          </WishTitleWrap>
           <Table
             colData={wishlistColData}
             data={wishlistData}
@@ -160,11 +171,19 @@ const TableSection = styled.div`
 const WishlistInfo = styled.div`
   display: flex;
   justify-content: flex-end;
-  margin-bottom: 10px;
+  margin-bottom: 1.4rem;
 
   span {
     margin-left: 20px;
   }
+`;
+
+const WishTitleWrap = styled(TableTitleWrap)`
+  display: flex;
+  align-items: center;
+  gap: 0 1rem;
+  height: 2.4rem;
+  margin-bottom: 0.8rem;
 `;
 
 const InfoBox = styled.div`
@@ -185,6 +204,18 @@ const InfoLabel = styled.span`
 const InfoValue = styled.span`
   font-size: 12px;
   font-weight: bold;
+`;
+
+const ButtonWrap = styled.button`
+  ${props => props.theme.texts.content};
+  background-color: ${props => props.theme.colors.secondary};
+  color: ${props => props.theme.colors.white};
+  min-width: 8.5rem;
+  height: 2.4rem;
+
+  &:hover {
+    filter: grayscale(15%);
+  }
 `;
 
 export default Wishlist;

--- a/src/components/common/Modal/AntiMacroCodeModal.tsx
+++ b/src/components/common/Modal/AntiMacroCodeModal.tsx
@@ -211,7 +211,7 @@ const InfoMessage = styled.p`
   font-weight: 600;
   position: absolute;
   bottom: 60px;
-  margin-left: 10px;
+  margin: 0 10px;
 `;
 const ModalFooter = styled.div`
   background: ${props => props.theme.colors.neutral5};

--- a/src/components/common/Modal/TimetableModal/TimetableBody.tsx
+++ b/src/components/common/Modal/TimetableModal/TimetableBody.tsx
@@ -1,0 +1,209 @@
+import React, {useCallback, useRef, useState} from 'react';
+import {styled} from 'styled-components';
+import {Schedule} from './WishTimetable';
+
+interface TimetableBodyProps {
+  days: string[];
+  timetable: Schedule[][];
+  setHoveredSubjects: React.Dispatch<React.SetStateAction<string[]>>;
+  setHoveredPosition: React.Dispatch<
+    React.SetStateAction<{
+      x: number;
+      y: number;
+    } | null>
+  >;
+}
+
+function TimetableBody({
+  days,
+  timetable,
+  setHoveredSubjects,
+  setHoveredPosition,
+}: TimetableBodyProps) {
+  const timeSlots = Array.from({length: 28}, (_, i) => {
+    const hourStart = 8 + Math.floor(i / 2);
+    const minuteStart = i % 2 === 0 ? '00' : '30';
+    const hourEnd = 8 + Math.floor((i + 1) / 2);
+    const minuteEnd = (i + 1) % 2 === 0 ? '00' : '30';
+
+    return {
+      start: `${hourStart}:${minuteStart}`,
+      end: `${hourEnd}:${minuteEnd}`,
+      label: `${hourStart}:${minuteStart} ~ ${hourEnd}:${minuteEnd}`,
+    };
+  });
+
+  const subjectColorsRef = useRef<Record<string, string>>({});
+  const [hoveredCell, setHoveredCell] = useState<string | null>(null);
+  const [hoveredSubject, setHoveredSubject] = useState<string | null>(null);
+
+  const handleMouseEnter = useCallback(
+    (subjects: string[], event: React.MouseEvent) => {
+      setHoveredSubjects(subjects);
+      setHoveredPosition({x: event.clientX, y: event.clientY});
+    },
+    [setHoveredPosition, setHoveredSubjects],
+  );
+
+  const handleMouseLeave = useCallback(() => {
+    setHoveredSubjects([]);
+    setHoveredPosition(null);
+  }, [setHoveredPosition, setHoveredSubjects]);
+
+  const getCellColor = (subjects: string[]) => {
+    const cellKey = subjects.join(',');
+    const getRandomColor = () => {
+      const hue = Math.floor(Math.random() * 360);
+      const saturation = 70;
+      const lightness = 80;
+
+      return `${hue}, ${saturation}%, ${lightness}%`;
+    };
+
+    if (!subjectColorsRef.current[cellKey]) {
+      subjectColorsRef.current[cellKey] = getRandomColor();
+    }
+
+    return subjectColorsRef.current[cellKey];
+  };
+
+  const isSlotOccupied = (dayIndex: number, rowIndex: number) => {
+    return timetable[dayIndex].some(
+      schedule => rowIndex >= schedule.start && rowIndex < schedule.end,
+    );
+  };
+
+  return (
+    <>
+      {timeSlots.map((slot, rowIndex) => (
+        <GridRow key={slot.start}>
+          <GridTimeSlot>{slot.label}</GridTimeSlot>
+          {days.map(
+            (_, colIndex) =>
+              !isSlotOccupied(colIndex, rowIndex) && (
+                <EmptyCell
+                  key={colIndex}
+                  style={{
+                    gridRow: `${rowIndex + 2}`,
+                    gridColumn: `${colIndex + 2}`,
+                  }}
+                />
+              ),
+          )}
+        </GridRow>
+      ))}
+      {timetable.map((daySchedule, dayIndex) =>
+        daySchedule.map((schedule, scheduleIndex) => {
+          const cellId = `${dayIndex}-${scheduleIndex}`;
+          const isHovered = hoveredCell === cellId;
+          const isRelated = hoveredSubject === schedule.subject;
+
+          return (
+            <GridCell
+              key={cellId}
+              style={{
+                gridRow: `${schedule.start + 2} / span ${schedule.end - schedule.start}`,
+                gridColumn: `${dayIndex + 2}`,
+                zIndex: scheduleIndex + 1,
+              }}
+              $backgroundColor={getCellColor(
+                schedule.overlaps || [schedule.subject],
+              )}
+              $hasEarlierOverlap={schedule.isEarlierOverlap}
+              $isHovered={isHovered}
+              $isRelated={isRelated}
+              onMouseEnter={e => {
+                setHoveredCell(cellId);
+                setHoveredSubject(schedule.subject);
+                handleMouseEnter(schedule.overlaps || [schedule.subject], e);
+              }}
+              onMouseLeave={() => {
+                setHoveredCell(null);
+                setHoveredSubject(null);
+                handleMouseLeave();
+              }}
+            >
+              <p>
+                {(schedule.showSubject ||
+                  !schedule.hasPartialOverlap ||
+                  isHovered ||
+                  isRelated) &&
+                  (schedule.overlaps && schedule.overlaps.length > 1
+                    ? `${schedule.overlaps[0]} 외 ${schedule.overlaps.length - 1}*`
+                    : schedule.subject)}
+              </p>
+            </GridCell>
+          );
+        }),
+      )}
+    </>
+  );
+}
+
+const GridRow = styled.div`
+  display: contents;
+`;
+
+const GridTimeSlot = styled.div`
+  ${props => props.theme.texts.tableTitle};
+  vertical-align: middle;
+  text-align: center;
+  padding: 10px;
+  background-color: #f0f0f0;
+  border: 1px solid #e5e5e5;
+  grid-column: 1;
+`;
+
+const GridCell = styled.div<{
+  $backgroundColor: string;
+  $hasEarlierOverlap?: boolean;
+  $isHovered: boolean;
+  $isRelated: boolean;
+}>`
+  ${props => props.theme.texts.content};
+  text-align: center;
+  vertical-align: middle;
+  position: relative;
+  padding: 8px;
+  text-align: center;
+  border: 1px solid #f0f0f0;
+  cursor: pointer;
+  transition:
+    transform 0.3s,
+    opacity 0.3s;
+  background-color: ${props => `hsla(${props.$backgroundColor}, 0.6)`};
+  color: #000;
+
+  p {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    word-wrap: break-word;
+  }
+
+  ${props =>
+    props.$hasEarlierOverlap &&
+    `
+    width: 88%;
+    border-radius: 0 14px 14px 0;
+    box-shadow: 3px 3px 6px rgba(0,0,0,0.2);
+    `}
+
+  ${props =>
+    (props.$isHovered || props.$isRelated) &&
+    `
+    opacity: 1;
+    transform: scale(1.05);
+    border-radius: 0;
+    z-index: 1000 !important;
+    background-color: ${`hsla(${props.$backgroundColor}, 1)`};
+  `}
+`;
+
+const EmptyCell = styled.div`
+  border: 1px solid #f0f0f0;
+`;
+
+export default TimetableBody;

--- a/src/components/common/Modal/TimetableModal/WishTimetable.tsx
+++ b/src/components/common/Modal/TimetableModal/WishTimetable.tsx
@@ -1,0 +1,188 @@
+import {useState} from 'react';
+import {styled} from 'styled-components';
+import TimetableBody from './TimetableBody';
+
+interface WishlistData {
+  curiNm: string | undefined;
+  lesnTime: string | undefined;
+}
+
+export interface Schedule {
+  subject: string;
+  start: number;
+  end: number;
+  overlaps?: string[];
+  showSubject?: boolean;
+  hasPartialOverlap?: boolean;
+  isEarlierOverlap?: boolean;
+}
+
+function WishTimetable({wishlistData}: {wishlistData: WishlistData[]}) {
+  const days = ['월', '화', '수', '목', '금'];
+  const [hoveredSubjects, setHoveredSubjects] = useState<string[]>([]);
+  const [hoveredPosition, setHoveredPosition] = useState<{
+    x: number;
+    y: number;
+  } | null>(null);
+
+  const timetable: Schedule[][] = Array.from({length: days.length}, () => []);
+
+  wishlistData.forEach(data => {
+    const timeInfo = data.lesnTime?.split(' ');
+    if (!timeInfo) return;
+
+    const times = timeInfo.filter(segment => segment.includes('~'));
+    const daysList = timeInfo.filter(segment => !segment.includes('~'));
+
+    daysList.forEach(day => {
+      times.forEach(timeRange => {
+        const [start, end] = timeRange.split('~');
+        const dayIndex = days.indexOf(day);
+
+        const [startHour, startMinute] = start.split(':').map(Number);
+        const [endHour, endMinute] = end.split(':').map(Number);
+
+        const startIndex = (startHour - 8) * 2 + (startMinute === 30 ? 1 : 0);
+        const endIndex = (endHour - 8) * 2 + (endMinute === 30 ? 1 : 0);
+
+        timetable[dayIndex].push({
+          subject: data.curiNm || '',
+          start: startIndex,
+          end: endIndex,
+        });
+      });
+    });
+  });
+
+  const sortSchedules = (
+    schedules: {subject: string; start: number; end: number}[],
+  ) => {
+    return schedules.sort((a, b) => {
+      if (a.start !== b.start) {
+        return a.start - b.start;
+      } else {
+        return b.end - b.start - (a.end - a.start);
+      }
+    });
+  };
+
+  const groupOverlappingSchedules = (schedules: Schedule[]): Schedule[] => {
+    const groups: Schedule[] = [];
+
+    schedules.forEach(schedule => {
+      const existingGroup = groups.find(
+        group => group.start === schedule.start && group.end === schedule.end,
+      );
+
+      if (existingGroup) {
+        existingGroup.overlaps = existingGroup.overlaps || [
+          existingGroup.subject,
+        ];
+        existingGroup.overlaps.push(schedule.subject);
+      } else {
+        const partialOverlaps = groups.filter(
+          group => group.start === schedule.start && group.end !== schedule.end,
+        );
+
+        if (partialOverlaps.length > 0) {
+          const allOverlaps = [...partialOverlaps, schedule].sort(
+            (a, b) => a.end - b.end,
+          );
+
+          allOverlaps.forEach((overlap, index) => {
+            overlap.showSubject = index === 0;
+            overlap.hasPartialOverlap = true;
+            overlap.isEarlierOverlap = index < allOverlaps.length - 1;
+          });
+        }
+
+        groups.push({...schedule, overlaps: [schedule.subject]});
+      }
+    });
+
+    return groups;
+  };
+
+  timetable.forEach((daySchedule, index) => {
+    const sortedSchedules = sortSchedules(daySchedule);
+    timetable[index] = groupOverlappingSchedules(sortedSchedules);
+  });
+
+  return (
+    <GridContainer>
+      <GridHeader>
+        <p>구분</p>
+        {days.map(day => (
+          <p key={day}>{day}</p>
+        ))}
+      </GridHeader>
+      <GridBody>
+        <TimetableBody
+          days={days}
+          timetable={timetable}
+          setHoveredSubjects={setHoveredSubjects}
+          setHoveredPosition={setHoveredPosition}
+        />
+      </GridBody>
+      {hoveredSubjects.length > 0 && hoveredPosition && (
+        <Tooltip style={{top: hoveredPosition.y + 30, left: hoveredPosition.x}}>
+          {hoveredSubjects.map((subject, index) => (
+            <p key={index}>{subject}</p>
+          ))}
+        </Tooltip>
+      )}
+    </GridContainer>
+  );
+}
+
+const GridContainer = styled.div`
+  width: 100%;
+  height: 100%;
+  min-height: 90rem;
+  max-width: 80rem;
+  border-collapse: collapse;
+  border: 1.6px solid #000;
+  display: grid;
+  grid-template-columns: 100px repeat(5, 1fr);
+  grid-template-rows: repeat(28, 1fr);
+  border: 1px solid #000;
+`;
+
+const GridHeader = styled.div`
+  display: contents;
+
+  p {
+    ${props => props.theme.texts.tableTitle};
+    text-align: center;
+    font-weight: bold;
+    padding: 10px;
+    background-color: #f0f0f0;
+    border: 1px solid #e5e5e5;
+  }
+`;
+
+const GridBody = styled.div`
+  display: contents;
+`;
+
+const Tooltip = styled.div`
+  position: fixed;
+  background: #fff;
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.2);
+  z-index: 1000;
+  white-space: nowrap;
+  pointer-events: none;
+  transition: opacity 0.3s ease-in-out;
+  max-width: 300px;
+  word-wrap: break-word;
+  opacity: 1;
+
+  p {
+    ${props => props.theme.texts.content};
+    padding: 0.4rem;
+  }
+`;
+
+export default WishTimetable;

--- a/src/components/common/Modal/TimetableModal/index.tsx
+++ b/src/components/common/Modal/TimetableModal/index.tsx
@@ -1,0 +1,175 @@
+import styled from 'styled-components';
+import close from '@assets/img/close-line.png';
+import {useDispatch} from 'react-redux';
+import {closeHandler} from '@components/common/Modal/handlers/handler.tsx';
+import {useCallback, useEffect, useMemo, useState} from 'react';
+import {getWishlist} from '@/apis/api/course';
+import {useAppSelector} from '@/store/hooks';
+import WishTimetable from './WishTimetable';
+
+interface WishlistData {
+  curiNm: string | undefined;
+  lesnTime: string | undefined;
+}
+
+function TimetableModal() {
+  const studentId = useAppSelector(state => state.userInfo.username);
+  const [wishlistData, setWishlistData] = useState<WishlistData[]>([]);
+  const dispatch = useDispatch();
+
+  const fetchWishlist = useCallback(async () => {
+    try {
+      const data = await getWishlist(studentId);
+      const processedData = data.map(({curiNm, lesnTime}) => ({
+        curiNm,
+        lesnTime,
+      }));
+      setWishlistData(processedData);
+    } catch (error) {
+      console.error('Failed to fetch wishlist:', error);
+    }
+  }, [studentId]);
+
+  useEffect(() => {
+    fetchWishlist();
+  }, [fetchWishlist]);
+
+  const isEmpty = useMemo(
+    () => (wishlistData.length === 0 ? true : false),
+    [wishlistData],
+  );
+
+  const closeButton = () => {
+    closeHandler(dispatch);
+    document.body.style.overflow = 'auto';
+  };
+
+  return (
+    <ModalContainer $isEmpty={isEmpty}>
+      <Modal $isEmpty={isEmpty}>
+        <ModalHeader>
+          <Title>관심과목 강의 시간표</Title>
+          <CloseImage onClick={closeButton} />
+        </ModalHeader>
+        <ModalBody>
+          {isEmpty ? (
+            <EmptyContent>관심과목이 없습니다.</EmptyContent>
+          ) : (
+            <WishTimetable wishlistData={wishlistData} />
+          )}
+        </ModalBody>
+        <ModalFooter>
+          <InfoMessage>
+            ※ 시간표가 표시되지 않는 경우 잠시 기다리거나 관심과목 강의 시간표
+            창을 닫고 새로 열어주세요.
+          </InfoMessage>
+          <FooterWrap>
+            <FooterBtn style={{marginRight: '20px'}} onClick={closeButton}>
+              닫기
+            </FooterBtn>
+          </FooterWrap>
+        </ModalFooter>
+      </Modal>
+    </ModalContainer>
+  );
+}
+
+const ModalContainer = styled.div<{$isEmpty: boolean}>`
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0);
+  display: flex;
+  justify-content: center;
+  z-index: 10;
+  overflow: auto;
+  position: ${({$isEmpty}) => ($isEmpty ? 'absolute' : 'fixed')};
+  align-items: ${({$isEmpty}) => ($isEmpty ? 'center' : 'flex-start')};
+`;
+
+const Modal = styled.div<{$isEmpty: boolean}>`
+  position: relative;
+  width: 82rem;
+  height: 100%;
+  border: 1px solid #000000;
+  background: #ffffff;
+  font-weight: lighter;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  margin: 3rem;
+  width: ${({$isEmpty}) => ($isEmpty ? '60rem' : '82rem')};
+  height: ${({$isEmpty}) => ($isEmpty ? '24rem' : '108rem')};
+`;
+
+const ModalHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  border-bottom: 1px solid #ababab;
+`;
+
+const Title = styled.div`
+  font-size: 2rem;
+  font-weight: bolder;
+  padding: 15px 30px;
+`;
+
+const CloseImage = styled.img.attrs({
+  src: `${close}`,
+})`
+  display: block;
+  width: 25px;
+  height: 25px;
+  cursor: pointer;
+  margin-top: 10px;
+  margin-right: 10px;
+`;
+
+const ModalBody = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+`;
+
+const EmptyContent = styled.div`
+  font-size: 1.8rem;
+`;
+
+const ModalFooter = styled.div`
+  width: 100%;
+  height: auto;
+  display: flex;
+  flex-direction: column;
+`;
+
+const InfoMessage = styled.p`
+  font-size: 1.3rem;
+  font-weight: 600;
+  margin: 1rem;
+`;
+
+const FooterWrap = styled.div`
+  background: ${props => props.theme.colors.neutral5};
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  height: 50px;
+`;
+
+const FooterBtn = styled.div`
+  font-size: 1.4rem;
+  border: 1px solid #000000;
+  background: #ffffff;
+  padding: 6px 15px;
+  cursor: pointer;
+
+  &:hover {
+    border: 1px solid ${props => props.theme.colors.primary};
+  }
+`;
+
+export default TimetableModal;

--- a/src/pages/index/Home.tsx
+++ b/src/pages/index/Home.tsx
@@ -16,6 +16,7 @@ import {useDispatch} from 'react-redux';
 import {clearModalInfo} from '@/store/modules/modalSlice';
 import ErrorModal from '@components/common/Modal/ErrorModal.tsx';
 import {useMediaQuery} from 'react-responsive';
+import TimetableModal from '@/components/common/Modal/TimetableModal';
 
 function Home() {
   const isPc = useMediaQuery({query: '(min-width: 1024px)'});
@@ -71,6 +72,8 @@ function Home() {
         return <InfoModal curiNm={courseName} type={'reload'} />;
       case 'fail':
         return <ErrorModal />;
+      case 'timetable':
+        return <TimetableModal />;
       case 'enrollment':
         return (
           <EnrollmentInfoModal


### PR DESCRIPTION
## Issue
- [TS-47](https://jeez.atlassian.net/browse/TS-47?atlOrigin=eyJpIjoiYzdjZWEzOGFhZTM2NDQ0ZGI3MTU2YjM5ZmJkMDRlNTYiLCJwIjoiaiJ9)
## Details
- 관심과목으로 등록한 수업들을 시간표로 볼 수 있도록 예상시간표 버튼과 시간표 모달을 추가했습니다.
![스크린샷 2025-01-23 174638](https://github.com/user-attachments/assets/9b38b1dd-7e06-4f46-b8ec-bd75005599fd)
    - 관심과목이 없는 경우의 모달
    ![스크린샷 2025-01-23 174708](https://github.com/user-attachments/assets/c713f288-5a07-4544-b2be-b4492cacf162)
- 시간표 모달이 열려있는 경우 불필요한 모달 바깥 스크롤을 못하도록 막았습니다.
   - 관심과목이 없는 경우: 스크롤 o
   - 관심과목이 있는 경우: 시간표가 모달에 뜨며 바깥 스크롤 x

- 각 수업 셀에 랜덤 색상을 주어 다른 수업과의 구분을 쉽게 하였고 투명도를 주어 시간이 겹치는 경우를 한 눈에 알아 볼 수 있도록 했습니다.
- 수업 셀에 마우스를 올렸을 때 시각효과를 넣어 강조되도록 하였고 툴팁을 띄워 해당 수업의 수업명을 확인할 수 있도록 했습니다.
- 수업명이 2줄 이상인 경우 말줄임표('...')로 줄이도록 했습니다. (툴팁에서 전체 수업명 확인 가능)
- 시간이 겹치는 경우 수업 셀을 나열하는 방법:
   - 시작 시간이 같은 경우 -> 끝나는 시간이 빠른 것이 앞으로 오도록 했습니다.
   - 시작 시간이 다른 경우 -> 시작 시간이 늦은 것이 앞으로 오도록 했습니다.
- 시간이 겹치는 수업 셀 시각화:
   - 시작 시간과 끝나는 시간이 모두 같은 경우 -> '경영학원론 외 1*' 과 같이 줄여서 표시했습니다.
        ![스크린샷 2025-01-21 215126](https://github.com/user-attachments/assets/f77620fc-ce65-456c-b07e-930650892c17)

   - 시작 시간은 같은데 끝나는 시간이 다른 경우 -> 끝나는 시간이 빠른 수업들의 사이즈를 작게하고 모서리를 둥글게 처리하여 뒤에 있는 수업에 마우스를 올려 확인 할 수 있게 했습니다.
   - 이때 셀을 가운데에 배치 한 경우 해당 수업에 마우스를 올리기 불편하다는 문제점이 발생하여 스타일과 배치를 약간 수정했습니다.
      - 이전 버전
    ![Untitledvideo-MadewithClipchamp4-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/f8ac1678-22ff-42b3-a1b2-74f7b8e7b26e)
      - 수정 후 버전
    ![Untitledvideo-MadewithClipchamp2-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/867c1772-832b-4efc-9257-74c3c74f336b)


[TS-47]: https://jeez.atlassian.net/browse/TS-47?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ