### PR TITLE
feat(TS-46): 인기 관심 과목 순위 추가

### DIFF
--- a/src/apis/api/course.ts
+++ b/src/apis/api/course.ts
@@ -20,6 +20,16 @@ export const getCourseList = async (filter: object) => {
   }
 };
 
+export const getWishRank = async () => {
+  try {
+    const {data} = await baseAPI.get('/schedules/popular?limit=5');
+
+    return data;
+  } catch (error) {
+    console.log('get wish rank fail: ', error);
+  }
+};
+
 export const saveWishlistItem = async (
   studentId: string,
   scheduleId: number,

--- a/src/assets/types/tableType.ts
+++ b/src/assets/types/tableType.ts
@@ -29,4 +29,6 @@ export interface CourseTypes {
   internshipTypeCdNm?: string | null;
   inoutSubCdtExchangeYn?: string | null;
   remark?: string;
+  rank?: number;
+  wishCount?: number;
 }

--- a/src/components/CourseRegister/index.tsx
+++ b/src/components/CourseRegister/index.tsx
@@ -5,13 +5,7 @@ import Table from '../common/Table';
 import {TableTitle, TableTitleWrap} from '../LectureList';
 import RegisteredList from './RegisteredList';
 import {useDispatch} from 'react-redux';
-import {
-  setCourseName,
-  setCuriTypeCdNm,
-  setModalName,
-  setSchDeptAlias,
-  setScheduleId,
-} from '@/store/modules/modalSlice';
+import {setCourseData, setModalName} from '@/store/modules/modalSlice';
 import StartButton from '@components/CourseRegister/StartButton.tsx';
 import {getCourseList, getRegisterdList, getWishlist} from '@/apis/api/course';
 import {useAppSelector} from '@/store/hooks';
@@ -104,11 +98,15 @@ function CourseRegister() {
     curiTypeCdNm: string | undefined,
   ) => {
     if (scheduleId && curiNm && schDeptAlias && curiTypeCdNm) {
-      dispatch(setScheduleId(scheduleId));
-      dispatch(setCourseName(curiNm));
+      dispatch(
+        setCourseData({
+          scheduleId: scheduleId,
+          curiNm: curiNm,
+          schDeptAlias: schDeptAlias,
+          curiTypeCdNm: curiTypeCdNm,
+        }),
+      );
       dispatch(setModalName('macro'));
-      dispatch(setSchDeptAlias(schDeptAlias));
-      dispatch(setCuriTypeCdNm(curiTypeCdNm));
     }
   };
 

--- a/src/components/WishRank/RankItem.tsx
+++ b/src/components/WishRank/RankItem.tsx
@@ -1,0 +1,54 @@
+import styled from 'styled-components';
+import {CourseTypes} from '@/assets/types/tableType';
+import {useAppDispatch} from '@/store/hooks';
+import {setCourseData} from '@/store/modules/modalSlice';
+import {openModalHandler} from '../common/Modal/handlers/handler';
+
+interface RankItemProps {
+  courseData: CourseTypes;
+}
+
+function RankItem({courseData}: RankItemProps) {
+  const dispatch = useAppDispatch();
+
+  const handleClick = () => {
+    openModalHandler(dispatch, 'wishrank');
+    dispatch(setCourseData(courseData));
+  };
+
+  return (
+    <RankWrap onClick={handleClick}>
+      <RankNo>{courseData.rank}</RankNo>
+      <p>{courseData.curiNm}</p>
+      <p>{courseData.lesnEmp}</p>
+    </RankWrap>
+  );
+}
+
+const RankWrap = styled.button`
+  ${props => props.theme.texts.tabTitle};
+  width: 100%;
+  display: grid;
+  grid-template-columns: 1fr 6fr 3fr;
+  align-items: center;
+  column-gap: 0.5rem;
+  padding: 0.7rem 0;
+  border-bottom: 1px solid ${props => props.theme.colors.neutral5};
+
+  > p {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    word-break: break-all;
+  }
+
+  &:hover {
+    background-color: ${props => props.theme.colors.neutral6};
+  }
+`;
+
+const RankNo = styled.p`
+  color: ${props => props.theme.colors.primary};
+`;
+
+export default RankItem;

--- a/src/components/WishRank/index.tsx
+++ b/src/components/WishRank/index.tsx
@@ -1,0 +1,50 @@
+import {getWishRank} from '@/apis/api/course';
+import {CourseTypes} from '@/assets/types/tableType';
+import {useEffect, useState} from 'react';
+import styled from 'styled-components';
+import RankItem from './RankItem';
+
+function WishRank() {
+  const [rank, setRank] = useState<CourseTypes[]>([]);
+
+  useEffect(() => {
+    const getRank = async () => {
+      const res = await getWishRank();
+      if (res) {
+        setRank(res);
+      }
+    };
+
+    getRank();
+  }, []);
+
+  return (
+    <RankContainer>
+      <RankTitle>인기 관심 과목 순위</RankTitle>
+      <RankBox>
+        {rank.map(lect => (
+          <RankItem key={lect.scheduleId} courseData={lect} />
+        ))}
+      </RankBox>
+    </RankContainer>
+  );
+}
+
+const RankContainer = styled.div`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 23rem;
+`;
+
+const RankTitle = styled.div`
+  ${props => props.theme.texts.subtitle};
+  margin-bottom: 1.5rem;
+  padding-left: 1rem;
+`;
+
+const RankBox = styled.div`
+  margin-bottom: 0.5rem;
+`;
+
+export default WishRank;

--- a/src/components/common/Modal/AntiMacroCodeModal.tsx
+++ b/src/components/common/Modal/AntiMacroCodeModal.tsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import close from '@assets/img/close-line.png';
 import {useEffect, useState} from 'react';
 import {getMacroCode} from '@apis/api/course.ts';
 import {useDispatch} from 'react-redux';
@@ -7,6 +6,14 @@ import {
   openModalHandler,
   closeHandler,
 } from '@components/common/Modal/handlers/handler.tsx';
+import {
+  CloseImage,
+  Modal,
+  ModalContainer,
+  ModalFooter,
+  ModalHeader,
+  Title,
+} from '@/styles/ModalLayout';
 
 interface MacroTypes {
   url: string;
@@ -59,7 +66,7 @@ function AntiMacroCodeModal() {
 
   return (
     <ModalContainer>
-      <Modal>
+      <MacroModal>
         <ModalHeader>
           <Title>매크로방지 코드입력 (Anti-macro code input) </Title>
           <CloseImage onClick={closeButton} />
@@ -99,52 +106,14 @@ function AntiMacroCodeModal() {
             닫기
           </FooterBtn>
         </ModalFooter>
-      </Modal>
+      </MacroModal>
     </ModalContainer>
   );
 }
 
-const ModalContainer = styled.div`
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0);
-  position: absolute;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 10;
-`;
-
-const Modal = styled.div`
-  position: relative;
-  width: 500px;
-  height: 312.5px;
-  border: 1px solid #000000;
-  background: #ffffff;
-  font-weight: lighter;
-`;
-
-const ModalHeader = styled.div`
-  display: flex;
-  justify-content: space-between;
-  border-bottom: 1px solid #ababab;
-`;
-
-const Title = styled.div`
-  font-size: 2rem;
-  font-weight: bolder;
-  padding: 15px 30px;
-`;
-
-const CloseImage = styled.img.attrs({
-  src: `${close}`,
-})`
-  display: block;
-  width: 25px;
-  height: 25px;
-  cursor: pointer;
-  margin-top: 10px;
-  margin-right: 10px;
+const MacroModal = styled(Modal)`
+  width: 50rem;
+  height: 31.25rem;
 `;
 
 const ModalBody = styled.div`
@@ -154,7 +123,7 @@ const ModalBody = styled.div`
 `;
 
 const MacroCodeBox = styled.div`
-  margin-left: 10px;
+  margin-left: 1rem;
 `;
 
 const BoxTitle = styled.p`
@@ -212,16 +181,6 @@ const InfoMessage = styled.p`
   position: absolute;
   bottom: 60px;
   margin: 0 10px;
-`;
-const ModalFooter = styled.div`
-  background: ${props => props.theme.colors.neutral5};
-  position: absolute;
-  width: 100%;
-  bottom: 0;
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  height: 50px;
 `;
 
 const FooterBtn = styled.div`

--- a/src/components/common/Modal/EnrollmentInfoModal.tsx
+++ b/src/components/common/Modal/EnrollmentInfoModal.tsx
@@ -1,25 +1,29 @@
 import styled, {css} from 'styled-components';
-import close from '@assets/img/close-line.png';
+import {closeHandler} from './handlers/handler';
+import {useAppDispatch, useAppSelector} from '@/store/hooks';
+import {
+  CloseImage,
+  Modal,
+  ModalContainer,
+  ModalFooter,
+  ModalHeader,
+  Title,
+} from '@/styles/ModalLayout';
 
-interface EnrollmentsProps {
-  schDeptAlias: string;
-  curiNo: string;
-  curiNm: string;
-  classNo: string;
-}
+function EnrollmentInfoModal() {
+  const dispatch = useAppDispatch();
+  const courseData = useAppSelector(state => state.modalInfo.courseData);
 
-function EnrollmentInfoModal({
-  schDeptAlias,
-  curiNo,
-  curiNm,
-  classNo,
-}: EnrollmentsProps) {
+  const closeButton = () => {
+    closeHandler(dispatch);
+  };
+
   return (
     <ModalContainer>
       <Modal>
         <ModalHeader>
           <Title>수강인원</Title>
-          <CloseImage />
+          <CloseImage onClick={closeButton} />
         </ModalHeader>
         <ModalBody>
           <LectureInfoContainer>
@@ -46,7 +50,7 @@ function EnrollmentInfoModal({
                 <LectureInfoWrap>
                   <span>개설학과전공</span>
                   <InputWrap sizes={'l'}>
-                    <p>{schDeptAlias}</p>
+                    <p>{courseData.schDeptAlias}</p>
                   </InputWrap>
                 </LectureInfoWrap>
                 <LectureInfoWrap>
@@ -59,11 +63,11 @@ function EnrollmentInfoModal({
                   <span>교과목번호-분반</span>
                   <InputWrap sizes={'s'}>
                     <p>
-                      {curiNo}-{classNo}
+                      {courseData.curiNo}-{courseData.classNo}
                     </p>
                   </InputWrap>
-                  <InputWrap sizes={'xl'}>
-                    <p>{curiNm}</p>
+                  <InputWrap sizes={'l'}>
+                    <p>{courseData.curiNm}</p>
                   </InputWrap>
                 </LectureInfoWrap>
               </LectureInfoBox>
@@ -89,8 +93,6 @@ function EnrollmentInfoModal({
                       9
                     </p>
                   </InputWrap>
-                </LectureInfoWrap>
-                <LectureInfoWrap>
                   <span>명</span>
                 </LectureInfoWrap>
                 <LectureInfoWrap>
@@ -110,8 +112,6 @@ function EnrollmentInfoModal({
                       0
                     </p>
                   </InputWrap>
-                </LectureInfoWrap>
-                <LectureInfoWrap>
                   <span>명</span>
                 </LectureInfoWrap>
               </LectureEnrollmentBox>
@@ -119,73 +119,31 @@ function EnrollmentInfoModal({
           </LectureInfoContainer>
         </ModalBody>
         <ModalFooter>
-          <FooterBtn style={{marginRight: '20px'}}>닫기</FooterBtn>
+          <FooterBtn style={{marginRight: '20px'}} onClick={closeButton}>
+            닫기
+          </FooterBtn>
         </ModalFooter>
       </Modal>
     </ModalContainer>
   );
 }
 
-const ModalContainer = styled.div`
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0);
-  position: absolute;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 10;
-`;
-
-const Modal = styled.div`
-  position: relative;
-  width: 790px;
-  height: 355px;
-  border: 2px solid #000000;
-  background: #ffffff;
-  font-weight: lighter;
-`;
-
-const ModalHeader = styled.div`
-  display: flex;
-  justify-content: space-between;
-  border-bottom: 1px solid #ababab;
-`;
-
-const Title = styled.div`
-  font-size: 2rem;
-  font-weight: bolder;
-  padding: 15px 30px;
-`;
-
-const CloseImage = styled.img.attrs({
-  src: `${close}`,
-})`
-    display: block;
-    width: 25px;
-    height: 25px;
-    cursor: pointer;
-    margin-top: 10px;
-    margin-right: 10px;
-`;
-
 const ModalBody = styled.div``;
 
 const LectureInfoContainer = styled.div`
-  width: 720px;
+  width: 72rem;
   border: 0.1rem solid #714656;
   border-radius: 2px;
   padding: 0.5rem 1.5rem;
-  margin: 30px auto;
+  margin: 3rem auto;
 `;
 
 const LectureInfoArea = styled.div``;
 
 const LectureInfoBox = styled.div`
-  width: 710px;
+  width: 71rem;
   display: flex;
   flex-wrap: wrap;
-  justify-content: flex-end;
   align-items: center;
   gap: 0.7rem 2.7rem;
 `;
@@ -197,28 +155,16 @@ const LectureInfoWrap = styled.div`
 
   > span {
     display: inline-block;
-    margin-right: 1rem;
     text-align: right;
-    min-width: 4.7rem;
+    min-width: 3rem;
   }
-`;
-
-const ModalFooter = styled.div`
-  background: ${props => props.theme.colors.neutral5};
-  position: absolute;
-  width: 100%;
-  bottom: 0;
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  height: 50px;
 `;
 
 const FooterBtn = styled.div`
   font-size: 1.4rem;
   border: 1px solid #000000;
   background: #ffffff;
-  padding: 6px 15px;
+  padding: 0.6rem 1.5rem;
   cursor: pointer;
 
   &:hover {
@@ -263,12 +209,10 @@ const InputWrap = styled.div<{sizes: string}>`
 `;
 
 const LectureEnrollmentBox = styled.div`
-  width: 710px;
   display: flex;
   flex-wrap: wrap;
-  justify-content: flex-end;
   align-items: center;
-  gap: 0.7rem 4.9rem;
+  gap: 0 7rem;
 `;
 
 export default EnrollmentInfoModal;

--- a/src/components/common/Modal/ErrorModal.tsx
+++ b/src/components/common/Modal/ErrorModal.tsx
@@ -1,9 +1,16 @@
 import styled from 'styled-components';
-import close from '@assets/img/close-line.png';
 import warning from '@assets/img/warning.png';
 import {useDispatch} from 'react-redux';
 import {closeHandler} from '@components/common/Modal/handlers/handler.tsx';
 import {useAppSelector} from '@/store/hooks';
+import {
+  CloseImage,
+  Modal,
+  ModalBody,
+  ModalContainer,
+  ModalFooter,
+  ModalHeader,
+} from '@/styles/ModalLayout';
 
 function ErrorModal() {
   const dispatch = useDispatch();
@@ -43,7 +50,7 @@ function ErrorModal() {
 
   return (
     <ModalContainer>
-      <Modal>
+      <WarningModal>
         <ModalHeader>
           <CloseImage onClick={closeButton} />
         </ModalHeader>
@@ -62,47 +69,14 @@ function ErrorModal() {
             </FooterBtn>
           </>
         </ModalFooter>
-      </Modal>
+      </WarningModal>
     </ModalContainer>
   );
 }
 
-const ModalContainer = styled.div`
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0);
-  position: absolute;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 10;
-`;
-
-const Modal = styled.div`
-  position: relative;
-  width: 500px;
-  height: 400px;
-  border: 1px solid #000000;
-  background: #ffffff;
-  font-weight: lighter;
-`;
-
-const ModalHeader = styled.div`
-  height: 50px;
-  display: flex;
-  justify-content: flex-end;
-  border-bottom: 1px solid #ababab;
-`;
-
-const CloseImage = styled.img.attrs({
-  src: `${close}`,
-})`
-  display: block;
-  width: 25px;
-  height: 25px;
-  cursor: pointer;
-  margin-top: 10px;
-  margin-right: 10px;
+const WarningModal = styled(Modal)`
+  width: 50rem;
+  height: 40rem;
 `;
 
 const WarningImage = styled.img.attrs({
@@ -113,26 +87,11 @@ const WarningImage = styled.img.attrs({
   margin: 0 auto 10px;
 `;
 
-const ModalBody = styled.div`
-  text-align: center;
-  margin-top: 15px;
-`;
-
 const InfoMessage = styled.p`
   font-size: 1.5rem;
   margin-bottom: 25px;
   line-height: 2.7rem;
   padding: 0 34px;
-`;
-const ModalFooter = styled.div`
-  background: ${props => props.theme.colors.neutral5};
-  position: absolute;
-  width: 100%;
-  bottom: 0;
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  height: 50px;
 `;
 
 const FooterBtn = styled.div<{type: string}>`

--- a/src/components/common/Modal/InfoModal.tsx
+++ b/src/components/common/Modal/InfoModal.tsx
@@ -1,19 +1,19 @@
 import styled from 'styled-components';
-import close from '@assets/img/close-line.png';
 import check from '@assets/img/check.png';
 import {useDispatch} from 'react-redux';
 import {
   closeHandler,
   openModalHandler,
 } from '@components/common/Modal/handlers/handler.tsx';
+import {
+  CloseImage,
+  Modal,
+  ModalBody,
+  ModalContainer,
+  ModalFooter,
+} from '@/styles/ModalLayout';
 
-function InfoModal({
-                     curiNm,
-                     type,
-                   }: {
-  curiNm: string;
-  type: string;
-}) {
+function InfoModal({curiNm, type}: {curiNm?: string; type: string}) {
   const dispatch = useDispatch();
 
   const eventHandler = async () => {
@@ -36,7 +36,7 @@ function InfoModal({
 
   return (
     <ModalContainer>
-      <Modal>
+      <InfoModalBox>
         <ModalHeader>
           <CloseImage onClick={closeButton} />
         </ModalHeader>
@@ -44,9 +44,7 @@ function InfoModal({
           <CheckImage />
           {type === 'check' ? (
             <>
-              <InfoMessage>
-                선택한 과목을 수강신청 하시겠습니까?
-              </InfoMessage>
+              <InfoMessage>선택한 과목을 수강신청 하시겠습니까?</InfoMessage>
               <InfoMessage>교과목명(Course Title) : {curiNm}</InfoMessage>
             </>
           ) : (
@@ -58,114 +56,73 @@ function InfoModal({
                 ※ 취소를 선택하실 경우 [수강신청내역]이 갱신되지 않습니다.
               </InfoMessage>
               <InfoMessage>
-                취소를 선택하실 경우 수강신청 최종 완료 후 반드시
-                [수강신청내역] 재조회를 눌러 신청내역을 확인하세요.
-                [수강신청내역]에 조회된 과목만이 정상적으로 수강신청된
-                과목입니다.
+                취소를 선택하실 경우 수강신청 최종 완료 후 반드시 [수강신청내역]
+                재조회를 눌러 신청내역을 확인하세요. [수강신청내역]에 조회된
+                과목만이 정상적으로 수강신청된 과목입니다.
               </InfoMessage>
             </>
           )}
         </ModalBody>
         <ModalFooter>
           <FooterBtn
-            type="cancel"
+            type='cancel'
             style={{marginRight: '10px'}}
             onClick={closeButton}
           >
             취소
           </FooterBtn>
           <FooterBtn
-            type="check"
+            type='check'
             style={{marginRight: '20px'}}
             onClick={eventHandler}
           >
             확인
           </FooterBtn>
         </ModalFooter>
-      </Modal>
+      </InfoModalBox>
     </ModalContainer>
   );
 }
 
-const ModalContainer = styled.div`
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0);
-    position: absolute;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 10;
-`;
-
-const Modal = styled.div`
-    position: relative;
-    width: 500px;
-    height: 400px;
-    border: 1px solid #000000;
-    background: #ffffff;
-    font-weight: lighter;
+const InfoModalBox = styled(Modal)`
+  width: 50rem;
+  height: 40rem;
 `;
 
 const ModalHeader = styled.div`
-    height: 50px;
-    display: flex;
-    justify-content: flex-end;
-    border-bottom: 1px solid #ababab;
+  height: 50px;
+  display: flex;
+  justify-content: flex-end;
+  border-bottom: 1px solid #ababab;
 `;
 
-const CloseImage = styled.img.attrs({
-  src: `${close}`,
-})`
-    display: block;
-    width: 25px;
-    height: 25px;
-    cursor: pointer;
-    margin-top: 10px;
-    margin-right: 10px;
-`;
 const CheckImage = styled.img.attrs({
   src: `${check}`,
 })`
-    display: block;
-    width: 50px;
-    margin: 0 auto 10px;
-`;
-
-const ModalBody = styled.div`
-    text-align: center;
-    margin-top: 15px;
+  display: block;
+  width: 50px;
+  margin: 0 auto 10px;
 `;
 
 const InfoMessage = styled.p`
-    font-size: 1.5rem;
-    margin-bottom: 25px;
-    line-height: 2.7rem;
-    padding: 0 34px;
-`;
-const ModalFooter = styled.div`
-    background: ${props => props.theme.colors.neutral5};
-    position: absolute;
-    width: 100%;
-    bottom: 0;
-    display: flex;
-    justify-content: flex-end;
-    align-items: center;
-    height: 50px;
+  font-size: 1.5rem;
+  margin-bottom: 25px;
+  line-height: 2.7rem;
+  padding: 0 34px;
 `;
 
 const FooterBtn = styled.div<{type: string}>`
-    font-size: 1.4rem;
-    border: 1px solid #000000;
-    background: ${props =>
-            props.type === 'check' ? props.theme.colors.primary : '#ffffff'};
-    color: ${props => (props.type === 'cancel' ? '#000000' : '#ffffff')};
-    padding: 6px 15px;
-    cursor: pointer;
+  font-size: 1.4rem;
+  border: 1px solid #000000;
+  background: ${props =>
+    props.type === 'check' ? props.theme.colors.primary : '#ffffff'};
+  color: ${props => (props.type === 'cancel' ? '#000000' : '#ffffff')};
+  padding: 6px 15px;
+  cursor: pointer;
 
-    &:hover {
-        border: 1px solid ${props => props.theme.colors.primary};
-    }
+  &:hover {
+    border: 1px solid ${props => props.theme.colors.primary};
+  }
 `;
 
 export default InfoModal;

--- a/src/components/common/Modal/LoadingModal.tsx
+++ b/src/components/common/Modal/LoadingModal.tsx
@@ -6,15 +6,16 @@ import {useDispatch} from 'react-redux';
 import {useAppSelector} from '@store/hooks';
 import {postCourse} from '@apis/api/course.ts';
 import {setType} from '@/store/modules/errorSlice';
+import {ModalContainer} from '@/styles/ModalLayout';
 
 interface LoadingModalProps {
-  scheduleId: number;
-  schDeptAlias: string;
-  curiTypeCdNm: string;
+  scheduleId?: number;
+  schDeptAlias?: string;
+  curiTypeCdNm?: string;
 }
 
 function LoadingModal({
-  scheduleId,
+  scheduleId = 0,
   schDeptAlias,
   curiTypeCdNm,
 }: LoadingModalProps) {
@@ -84,17 +85,6 @@ function LoadingModal({
     </ModalContainer>
   );
 }
-
-const ModalContainer = styled.div`
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0);
-  position: absolute;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 10;
-`;
 
 const LoadingContainer = styled.div`
   background: #ffffff;

--- a/src/components/common/Modal/RankInfoModal.tsx
+++ b/src/components/common/Modal/RankInfoModal.tsx
@@ -1,0 +1,123 @@
+import {useAppDispatch, useAppSelector} from '@/store/hooks';
+import {
+  CloseImage,
+  Modal,
+  ModalBody,
+  ModalContainer,
+  ModalFooter,
+  ModalHeader,
+  Title,
+} from '@/styles/ModalLayout';
+import {closeHandler} from './handlers/handler';
+import styled from 'styled-components';
+
+function RankInfoModal() {
+  const dispatch = useAppDispatch();
+  const courseData = useAppSelector(state => state.modalInfo.courseData);
+
+  const closeButton = () => {
+    closeHandler(dispatch);
+  };
+
+  return (
+    <ModalContainer>
+      <WishModal>
+        <ModalHeader>
+          <Title>강의 정보</Title>
+          <CloseImage onClick={closeButton} />
+        </ModalHeader>
+        <WishModalBody>
+          <InfoBox>
+            <InfoWrap>
+              <LabelWrap>과목명</LabelWrap>
+              <ContentWrap>{courseData.curiNm}</ContentWrap>
+            </InfoWrap>
+            <InfoWrap>
+              <LabelWrap>분반</LabelWrap>
+              <ContentWrap>{courseData.classNo}</ContentWrap>
+            </InfoWrap>
+            <InfoWrap>
+              <LabelWrap>관심 과목 담은 수</LabelWrap>
+              <ContentWrap>{courseData.wishCount}</ContentWrap>
+            </InfoWrap>
+            <InfoWrap>
+              <LabelWrap>개설학과</LabelWrap>
+              <ContentWrap>{courseData.manageDeptNm}</ContentWrap>
+            </InfoWrap>
+            <InfoWrap>
+              <LabelWrap>담당 교수명</LabelWrap>
+              <ContentWrap>{courseData.lesnEmp}</ContentWrap>
+            </InfoWrap>
+            <InfoWrap>
+              <LabelWrap>강의시간</LabelWrap>
+              <ContentWrap>{courseData.lesnTime}</ContentWrap>
+            </InfoWrap>
+            <InfoWrap>
+              <LabelWrap>강의실</LabelWrap>
+              <ContentWrap>{courseData.lesnRoom}</ContentWrap>
+            </InfoWrap>
+          </InfoBox>
+        </WishModalBody>
+        <ModalFooter>
+          <FooterBtn style={{marginRight: '20px'}} onClick={closeButton}>
+            닫기
+          </FooterBtn>
+        </ModalFooter>
+      </WishModal>
+    </ModalContainer>
+  );
+}
+
+const WishModal = styled(Modal)`
+  min-height: 26rem;
+  height: fit-content;
+`;
+
+const WishModalBody = styled(ModalBody)`
+  margin: 1.5rem 3rem;
+`;
+
+const InfoBox = styled.div`
+  border: 0.1rem solid #714656;
+  display: flex;
+  flex-wrap: wrap;
+  width: 73rem;
+  padding: 1.5rem 1rem;
+  gap: 1.2rem 1rem;
+`;
+
+const InfoWrap = styled.div`
+  ${props => props.theme.texts.tableTitle};
+  display: flex;
+  align-items: center;
+`;
+
+const LabelWrap = styled.div`
+  min-width: 6rem;
+`;
+
+const ContentWrap = styled.div`
+  ${props => props.theme.texts.content};
+  display: flex;
+  align-items: center;
+  border: 1px solid ${props => props.theme.colors.neutral5};
+  border-radius: 2px;
+  background: ${props => props.theme.colors.neutral5};
+  height: 2.4rem;
+  margin-left: 1rem;
+  padding: 1rem 5rem;
+`;
+
+const FooterBtn = styled.div`
+  font-size: 1.4rem;
+  border: 1px solid #000000;
+  background: #ffffff;
+  padding: 0.6rem 1.5rem;
+  cursor: pointer;
+
+  &:hover {
+    border: 1px solid ${props => props.theme.colors.primary};
+  }
+`;
+
+export default RankInfoModal;

--- a/src/components/common/Modal/WaitingModal.tsx
+++ b/src/components/common/Modal/WaitingModal.tsx
@@ -5,6 +5,7 @@ import {useEffect, useState} from 'react';
 import {useDispatch} from 'react-redux';
 import {clearModalInfo} from '@/store/modules/modalSlice';
 import {getRandomInt} from '@/utils/randomUtils.ts';
+import {Modal, ModalContainer} from '@/styles/ModalLayout';
 
 function WaitingModal() {
   const dispatch = useDispatch();
@@ -62,7 +63,7 @@ function WaitingModal() {
 
   return (
     <ModalContainer>
-      <Modal>
+      <WaitingModalBox>
         <Logo />
         <Title>
           서비스{' '}
@@ -96,32 +97,19 @@ function WaitingModal() {
           <CloseImage src={close} /> 중지
         </StopButton>
         <Contents>재 접속하시면 대기시간이 더 길어집니다.</Contents>
-      </Modal>
+      </WaitingModalBox>
     </ModalContainer>
   );
 }
 
-const ModalContainer = styled.div`
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0);
-  position: absolute;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-  z-index: 10;
-`;
-
-const Modal = styled.div`
-  width: 390px;
-  height: 430px;
-  min-width: 390px;
-  min-height: 430px;
-  border: 1px solid #000000;
-  background: #ffffff;
+const WaitingModalBox = styled(Modal)`
+  position: static;
+  width: 39rem;
+  height: 43rem;
+  min-width: 39rem;
+  min-height: 43rem;
   font-weight: lighter;
-  padding: 20px 40px;
+  padding: 2rem 4rem;
   word-break: unset;
   display: flex;
   flex-direction: column;

--- a/src/pages/index/Home.tsx
+++ b/src/pages/index/Home.tsx
@@ -17,6 +17,8 @@ import {clearModalInfo} from '@/store/modules/modalSlice';
 import ErrorModal from '@components/common/Modal/ErrorModal.tsx';
 import {useMediaQuery} from 'react-responsive';
 import TimetableModal from '@/components/common/Modal/TimetableModal';
+import WishRank from '@/components/WishRank';
+import RankInfoModal from '@/components/common/Modal/RankInfoModal';
 
 function Home() {
   const isPc = useMediaQuery({query: '(min-width: 1024px)'});
@@ -27,8 +29,7 @@ function Home() {
     setBarOpen(isPc);
   }, [isPc]);
 
-  const {modalName, scheduleId, courseName, schDeptAlias, curiTypeCdNm} =
-    useAppSelector(state => state.modalInfo);
+  const {modalName, courseData} = useAppSelector(state => state.modalInfo);
 
   const focusedTab = tab.find(tab => tab.id === focused);
   const focusedTabName = focusedTab ? focusedTab.name : '선택된 탭이 없습니다.';
@@ -59,30 +60,25 @@ function Home() {
       case 'macro':
         return <AntiMacroCodeModal />;
       case 'check':
-        return <InfoModal curiNm={courseName} type={'check'} />;
+        return <InfoModal curiNm={courseData.curiNm} type={'check'} />;
       case 'loading':
         return (
           <LoadingModal
-            scheduleId={scheduleId}
-            schDeptAlias={schDeptAlias}
-            curiTypeCdNm={curiTypeCdNm}
+            scheduleId={courseData.scheduleId}
+            schDeptAlias={courseData.schDeptAlias}
+            curiTypeCdNm={courseData.curiTypeCdNm}
           />
         );
       case 'reload':
-        return <InfoModal curiNm={courseName} type={'reload'} />;
+        return <InfoModal curiNm={courseData.curiNm} type={'reload'} />;
       case 'fail':
         return <ErrorModal />;
       case 'timetable':
         return <TimetableModal />;
       case 'enrollment':
-        return (
-          <EnrollmentInfoModal
-            schDeptAlias={''}
-            curiNo={''}
-            classNo={''}
-            curiNm={courseName}
-          />
-        );
+        return <EnrollmentInfoModal />;
+      case 'wishrank':
+        return <RankInfoModal />;
       default:
         return <></>;
     }
@@ -94,6 +90,7 @@ function Home() {
       <Header />
       <Box>
         <Menubar open={barOpen} setOpen={setBarOpen} />
+        {barOpen && <WishRank />}
         <Main $isOpen={barOpen}>
           <TabMenu />
           <Article>

--- a/src/store/modules/modalSlice.ts
+++ b/src/store/modules/modalSlice.ts
@@ -1,60 +1,45 @@
-import {createSlice} from '@reduxjs/toolkit';
+import {CourseTypes} from '@/assets/types/tableType';
+import {createSlice, PayloadAction} from '@reduxjs/toolkit';
 
 export interface ModalInfo {
   modalName: string;
-  scheduleId: number;
-  courseName: string;
-  schDeptAlias: string;
-  curiTypeCdNm: string;
+  courseData: CourseTypes;
 }
+
+const initialState: ModalInfo = {
+  modalName: '',
+  courseData: {
+    scheduleId: 0,
+    schDeptAlias: '',
+    curiTypeCdNm: '',
+    curiNo: '',
+    classNo: '',
+    curiNm: '',
+    manageDeptNm: '',
+    lesnEmp: '',
+    lesnTime: '',
+    lesnRoom: '',
+    rank: 1,
+    wishCount: 0,
+  },
+};
 
 const modalInfo = createSlice({
   name: 'modalInfo',
-  initialState: {
-    modalName: '',
-    scheduleId: 0,
-    courseName: '',
-    schDeptAlias: '',
-    curiTypeCdNm: '',
-  },
+  initialState: initialState,
   reducers: {
     setModalName(state: ModalInfo, {payload}: {payload: string}) {
       state.modalName = payload;
     },
-
-    setScheduleId(state: ModalInfo, {payload}: {payload: number}) {
-      state.scheduleId = payload;
+    setCourseData: (state, action: PayloadAction<Partial<CourseTypes>>) => {
+      state.courseData = {...state.courseData, ...action.payload};
     },
-
-    setCourseName(state: ModalInfo, {payload}: {payload: string}) {
-      state.courseName = payload;
-    },
-
-    setSchDeptAlias(state: ModalInfo, {payload}: {payload: string}) {
-      state.schDeptAlias = payload;
-    },
-
-    setCuriTypeCdNm(state: ModalInfo, {payload}: {payload: string}) {
-      state.curiTypeCdNm = payload;
-    },
-
-    clearModalInfo(state: ModalInfo) {
-      state.modalName = '';
-      state.scheduleId = 0;
-      state.courseName = '';
-      state.schDeptAlias = '';
-      state.curiTypeCdNm = '';
+    clearModalInfo: () => {
+      return initialState;
     },
   },
 });
 
-export const {
-  setModalName,
-  setScheduleId,
-  setCourseName,
-  setSchDeptAlias,
-  setCuriTypeCdNm,
-  clearModalInfo,
-} = modalInfo.actions;
+export const {setModalName, setCourseData, clearModalInfo} = modalInfo.actions;
 
 export default modalInfo.reducer;

--- a/src/styles/ModalLayout.tsx
+++ b/src/styles/ModalLayout.tsx
@@ -1,0 +1,62 @@
+import styled from 'styled-components';
+import close from '@assets/img/close-line.png';
+
+export const ModalContainer = styled.div`
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0);
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 10;
+`;
+
+export const Modal = styled.div`
+  position: relative;
+  width: 79rem;
+  height: 35.5rem;
+  border: 1px solid ${props => props.theme.colors.black};
+  background: ${props => props.theme.colors.white};
+  font-weight: lighter;
+`;
+
+export const ModalHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  border-bottom: 1px solid #ababab;
+  height: 5rem;
+`;
+
+export const Title = styled.div`
+  font-size: 2rem;
+  font-weight: bolder;
+  padding: 1.5rem 3rem;
+`;
+
+export const CloseImage = styled.img.attrs({
+  src: `${close}`,
+})`
+  display: block;
+  width: 2.5rem;
+  height: 2.5rem;
+  cursor: pointer;
+  margin-top: 1rem;
+  margin-right: 1rem;
+`;
+
+export const ModalBody = styled.div`
+  text-align: center;
+  margin-top: 1.5rem;
+`;
+
+export const ModalFooter = styled.div`
+  background: ${props => props.theme.colors.neutral5};
+  position: absolute;
+  width: 100%;
+  bottom: 0;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  height: 5rem;
+`;


### PR DESCRIPTION
## Issue
- [TS-46](https://jeez.atlassian.net/browse/TS-46?atlOrigin=eyJpIjoiMTNiNDY3NzllMDUzNGJmYjg4NDAzZTJjY2NhNTUwNjgiLCJwIjoiaiJ9)
## Details
![스크린샷 2025-01-24 022020](https://github.com/user-attachments/assets/20875e72-fe78-4084-842f-bd1e8e1b3330)
- 인기 관심 과목 5개를 불러오도록 했습니다.
- 좌측하단에 고정되도록 했습니다.
![image](https://github.com/user-attachments/assets/74872fe2-d426-4c1b-9301-6f2d33c48ad2)
- 클릭 했을 때 세부 정보를 볼 수 있는 모달을 추가했습니다.
- 모달 띄울 때 필요한 데이터들을  id, 이름 등 각각 따로 스토어에 업데이트하던 방식에서 객체 데이터로 한 번에 저장하도록 변경했습니다.
`
dispatch(setCourseData(Object));
` 
또는
`
dispatch(
    setCourseData({
        scheduleId: scheduleId,
        curiNm: curiNm}));
` 처럼 일부만 데이터를 업데이트할 수 있습니다.
- 자주 사용되거나 겹치는 모달 레이아웃을 styles/ModalLayout.tsx에 분리했습니다.

[TS-46]: https://jeez.atlassian.net/browse/TS-46?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ