### PR TITLE
refactor(TS-56): 수강신청 안내문 업데이트 및 레이아웃 수정

### DIFF
--- a/src/components/CourseRegister/InfoContent.tsx
+++ b/src/components/CourseRegister/InfoContent.tsx
@@ -7,7 +7,7 @@ function InfoContent() {
       <Container>
         <SubTitle>2025-1학기 수강신청 연습 안내</SubTitle>
         <p>
-          <span>1. 시간표 업데이트 일정:</span> 1.24.(금)
+          <span>1. 관심과목 담기:</span> 1.24.(금) 16:00 ~ 1.31.(금) 16:00
         </p>
         <p>
           <span>2. 수강신청 주요일정</span>
@@ -23,48 +23,54 @@ function InfoContent() {
           </thead>
           <tbody>
             <tr>
-              <td rowSpan={5}>수강신청</td>
+              <td rowSpan={6}>수강신청</td>
               <td>
                 4학년(7~8학기 등록 예정자), <br /> 건축학 5학년, 수업연한초과자
               </td>
-              <td>2.17.(월) 10:00 ~ 17:00</td>
-              <td rowSpan={4}>
-                소속학부(과)의 주·복수·부
+              <td>2.11.(화) 10:00 ~ 17:00</td>
+              <Note rowSpan={4}>
+                소속학부(과)의 주·복수·
                 <br />
-                전공과목과 교양과목만 수강신청 <br />
-                가능
-              </td>
+                부전공과목과 교양과목만
+                <br /> 수강신청 가능
+              </Note>
             </tr>
             <tr>
               <td>3학년(5~6학기 등록 예정자)</td>
-              <td>2.18.(화) 10:00 ~ 17:00</td>
+              <td>2.12.(수) 10:00 ~ 17:00</td>
             </tr>
             <tr>
               <td>2학년(3~4학기 등록 예정자)</td>
-              <td>2.19.(수) 10:00 ~ 17:00</td>
+              <td rowSpan={2}>2.13.(목) 10:00 ~ 17:00</td>
             </tr>
             <tr>
               <td>1학년(1~2학기 등록 예정자)</td>
-              <td>2.20.(목) 10:00 ~ 17:00</td>
             </tr>
             <tr>
               <td>전학년</td>
-              <td>2.21.(금) 10:00 ~ 17:00</td>
-              <td>
-                다른 학과 전공과목도 수강신청
-                <br /> 가능
-              </td>
+              <td>2.14.(금) 10:00 ~ 17:00</td>
+              <Note>
+                다른 학과 전공과목도 수강
+                <br />
+                신청 가능
+              </Note>
+            </tr>
+            <tr>
+              <td>신입생, 편입생</td>
+              <td>2.28.(금) 10:00 ~ 17:00</td>
+              <Note>※ 변경가능</Note>
             </tr>
             <tr>
               <td>
                 수강신청과목 <br /> 확인 및 변경
               </td>
               <td>전학년</td>
-              <td>2. 25.(화) ~ 2.28.(금) 10:00 ~ 17:00</td>
-              <td>
-                다른 학과 전공과목도 수강신청
-                <br /> 가능
-              </td>
+              <td>3. 5.(수) ~ 3.10.(월) 10:00 ~ 17:00</td>
+              <Note>
+                다른 학과 전공과목도 수강
+                <br />
+                신청 가능
+              </Note>
             </tr>
           </tbody>
         </Table>
@@ -74,10 +80,10 @@ function InfoContent() {
         </p>
         <p>본인의 학과를 선택하고, 수강신청 날짜를 지정합니다.</p>
         <p>
-          - 본인 학년 선택 -&gt; 본인 소속학부(과)의 주·복수·부전공과목과
-          교양과목만 수강신청 가능
+          - 본인 학년 선택: 본인 소속학부(과)의 주·복수·부전공과목과 교양과목만
+          수강신청 가능
         </p>
-        <p>- 전학년 선택 -&gt; 다른 학과 전공과목도 수강신청가능</p>
+        <p>- 전학년 선택: 다른 학과 전공과목도 수강신청가능</p>
         <p>
           학과를 선택하지 않을 경우, 학과 제한이 없는 전학년 수강신청 날짜로
           자동 설정됩니다.
@@ -104,7 +110,7 @@ const Container = styled.div`
   > p {
     font-weight: normal;
     font-size: 1.4rem;
-    margin-bottom: 8px;
+    margin-bottom: 0.8rem;
     line-height: 1.6;
     letter-spacing: 0.01em;
 
@@ -123,9 +129,9 @@ const SubTitle = styled.div`
 `;
 
 const Table = styled.table`
-  width: 90%;
+  width: 70%;
   height: auto;
-  max-width: 70rem;
+  max-width: 60rem;
   border-collapse: collapse;
   border: 1.6px solid #000;
 
@@ -148,6 +154,10 @@ const Table = styled.table`
     word-break: break-all;
     background-color: white;
   }
+`;
+
+const Note = styled.td`
+  text-align: start !important;
 `;
 
 export default InfoContent;

--- a/src/components/LoginForm/index.tsx
+++ b/src/components/LoginForm/index.tsx
@@ -41,7 +41,6 @@ function LoginForm({isTermsCheck}: {isTermsCheck: boolean}) {
       });
   };
   const handleLogin = async () => {
-
     ReactGA.event({
       category: 'User',
       action: 'Login Attempt',
@@ -166,7 +165,7 @@ const RandomStudentIdContainer = styled.div`
 
 const RandomStudentIdInput = styled.p`
   border-bottom: 1px solid #000000;
-  padding: 5px 10px;
+  padding: 0.5rem 1rem;
   font-size: 1.7rem;
   font-weight: 700;
   flex: 1 1 0;
@@ -174,12 +173,12 @@ const RandomStudentIdInput = styled.p`
 
 const GenerateButton = styled.button`
   display: block;
-  padding: 10px;
+  padding: 1rem;
   font-size: 1.7rem;
   font-weight: 700;
 
   > img {
-    width: 20px;
+    width: 2rem;
   }
 `;
 

--- a/src/components/Menubar/Menu.tsx
+++ b/src/components/Menubar/Menu.tsx
@@ -49,7 +49,7 @@ const MenuTitleBox = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 15px;
+  padding: 0 1.5rem;
   border-bottom: 1px solid ${props => props.theme.colors.neutral5};
 `;
 

--- a/src/components/Menubar/MenuItem.tsx
+++ b/src/components/Menubar/MenuItem.tsx
@@ -33,9 +33,9 @@ const DetailWrap = styled.button<{$isactive: boolean}>`
   display: flex;
   align-items: center;
   column-gap: 1rem;
-  padding-left: 10px;
-  border-radius: 5px;
-  margin-top: 5px;
+  padding-left: 1rem;
+  border-radius: 0.5rem;
+  margin-top: 0.5rem;
   background-color: ${props =>
     props.$isactive ? props.theme.colors.primary : 'transparent'};
   color: ${props => props.$isactive && props.theme.colors.white};

--- a/src/components/Menubar/index.tsx
+++ b/src/components/Menubar/index.tsx
@@ -28,11 +28,7 @@ function Menubar({open, setOpen}: BarProps) {
 const BarContainer = styled.div<{$open: boolean}>`
   min-width: ${props => (props.$open ? '23rem' : '2rem')};
   background-color: ${props => props.theme.colors.white};
-
-  @media ${props => props.theme.device.mobile} {
-    position: absolute;
-    z-index: 999;
-  }
+  height: 100%;
 `;
 
 const BarBox = styled.div``;

--- a/src/components/Wishlist/index.tsx
+++ b/src/components/Wishlist/index.tsx
@@ -171,7 +171,7 @@ const WishlistContainer = styled.div`
 
 const TableWrapper = styled.div`
   display: flex;
-  gap: 20px;
+  gap: 2rem;
 `;
 
 const TableSection = styled.div`
@@ -186,7 +186,7 @@ const WishlistInfo = styled.div`
   margin-bottom: 1.4rem;
 
   span {
-    margin-left: 20px;
+    margin-left: 2rem;
   }
 `;
 
@@ -202,19 +202,19 @@ const InfoBox = styled.div`
   background-color: #f0f0f0;
   border: 1px solid #ddd;
   border-radius: 4px;
-  padding: 5px 10px;
-  margin: 2px;
+  padding: 0.5rem 1rem;
+  margin: 0.2rem;
   display: flex;
   align-items: center;
 `;
 
 const InfoLabel = styled.span`
-  font-size: 12px;
-  margin-right: 5px;
+  font-size: 1.2rem;
+  margin-right: 0.5rem;
 `;
 
 const InfoValue = styled.span`
-  font-size: 12px;
+  font-size: 1.2rem;
   font-weight: bold;
 `;
 

--- a/src/components/common/Modal/AntiMacroCodeModal.tsx
+++ b/src/components/common/Modal/AntiMacroCodeModal.tsx
@@ -135,15 +135,15 @@ const BoxTitle = styled.p`
 `;
 
 const MacroCodeInputBox = styled.div`
-  margin-right: 10px;
+  margin-right: 1rem;
 `;
 
 const MacroCodHeader = styled.div`
-  height: 30px;
+  height: 3rem;
   display: flex;
   justify-content: left;
   align-items: center;
-  margin-top: 10px;
+  margin-top: 1rem;
 `;
 
 const RegenerateCodeButton = styled.div`
@@ -151,9 +151,9 @@ const RegenerateCodeButton = styled.div`
   color: #ffffff;
   border-radius: 3px;
   font-size: 1.4rem;
-  padding: 8px 15px;
+  padding: 0.8rem 1.5rem;
   text-align: center;
-  margin-left: 20px;
+  margin-left: 2rem;
   cursor: pointer;
 
   &:hover {
@@ -162,32 +162,32 @@ const RegenerateCodeButton = styled.div`
 `;
 
 const MacroCodeImage = styled.img`
-  margin-top: 10px;
-  width: 120px;
+  margin-top: 1rem;
+  width: 12rem;
 `;
 
 const MacroCodeInput = styled.input`
-  width: 200px;
+  width: 20rem;
   border: 1px solid #858181;
   border-radius: 0;
   font-size: 1.3rem;
-  padding: 6px 8px;
-  margin-top: 10px;
+  padding: 0.6rem 0.8rem;
+  margin-top: 1rem;
 `;
 
 const InfoMessage = styled.p`
   font-size: 1.3rem;
   font-weight: 600;
   position: absolute;
-  bottom: 60px;
-  margin: 0 10px;
+  bottom: 6rem;
+  margin: 0 1rem;
 `;
 
 const FooterBtn = styled.div`
   font-size: 1.4rem;
   border: 1px solid #000000;
   background: #ffffff;
-  padding: 6px 15px;
+  padding: 0.6rem 1.5rem;
   cursor: pointer;
 
   &:hover {

--- a/src/components/common/Modal/ErrorModal.tsx
+++ b/src/components/common/Modal/ErrorModal.tsx
@@ -83,15 +83,15 @@ const WarningImage = styled.img.attrs({
   src: `${warning}`,
 })`
   display: block;
-  width: 50px;
-  margin: 0 auto 10px;
+  width: 5rem;
+  margin: 0 auto 1rem;
 `;
 
 const InfoMessage = styled.p`
   font-size: 1.5rem;
   margin-bottom: 25px;
   line-height: 2.7rem;
-  padding: 0 34px;
+  padding: 0 3.4rem;
 `;
 
 const FooterBtn = styled.div<{type: string}>`
@@ -100,7 +100,7 @@ const FooterBtn = styled.div<{type: string}>`
   background: ${props =>
     props.type === 'check' ? props.theme.colors.primary : '#ffffff'};
   color: ${props => (props.type === 'cancel' ? '#000000' : '#ffffff')};
-  padding: 6px 15px;
+  padding: 0.6rem 1.5rem;
   cursor: pointer;
 
   &:hover {

--- a/src/components/common/Modal/LoadingModal.tsx
+++ b/src/components/common/Modal/LoadingModal.tsx
@@ -99,16 +99,16 @@ function LoadingModal({
 
 const LoadingContainer = styled.div`
   background: #ffffff;
-  width: 300px;
-  padding: 10px;
+  width: 30rem;
+  padding: 1rem;
   border: 1px solid #ccc;
   border-radius: 4px;
   text-align: center;
 `;
 
 const LoadingText = styled.div`
-  margin-bottom: 10px;
-  font-size: 16px;
+  margin-bottom: 1rem;
+  font-size: 1.6rem;
 `;
 
 const move = keyframes`
@@ -116,13 +116,13 @@ const move = keyframes`
         background-position: 0 0;
     }
     100% {
-        background-position: 50px 0;
+        background-position: 5rem 0;
     }
 `;
 
 const LoadingBar = styled.div`
   width: 100%;
-  height: 20px;
+  height: 2rem;
   border-radius: 4px;
   background-color: #e0e0e0;
   overflow: hidden;

--- a/src/components/common/Modal/TimetableModal/TimetableBody.tsx
+++ b/src/components/common/Modal/TimetableModal/TimetableBody.tsx
@@ -109,7 +109,7 @@ function TimetableBody({
               $backgroundColor={getCellColor(
                 schedule.overlaps || [schedule.subject],
               )}
-              $hasEarlierOverlap={schedule.isEarlierOverlap}
+              $isEarlierOverlap={schedule.isEarlierOverlap}
               $isHovered={isHovered}
               $isRelated={isRelated}
               onMouseEnter={e => {
@@ -148,7 +148,7 @@ const GridTimeSlot = styled.div`
   ${props => props.theme.texts.tableTitle};
   vertical-align: middle;
   text-align: center;
-  padding: 10px;
+  padding: 1rem;
   background-color: #f0f0f0;
   border: 1px solid #e5e5e5;
   grid-column: 1;
@@ -156,7 +156,7 @@ const GridTimeSlot = styled.div`
 
 const GridCell = styled.div<{
   $backgroundColor: string;
-  $hasEarlierOverlap?: boolean;
+  $isEarlierOverlap?: boolean;
   $isHovered: boolean;
   $isRelated: boolean;
 }>`
@@ -164,7 +164,7 @@ const GridCell = styled.div<{
   text-align: center;
   vertical-align: middle;
   position: relative;
-  padding: 8px;
+  padding: 0.8rem;
   text-align: center;
   border: 1px solid #f0f0f0;
   cursor: pointer;
@@ -184,10 +184,10 @@ const GridCell = styled.div<{
   }
 
   ${props =>
-    props.$hasEarlierOverlap &&
+    props.$isEarlierOverlap &&
     `
     width: 88%;
-    border-radius: 0 14px 14px 0;
+    border-radius: 0 1.4rem 1.4rem 0;
     box-shadow: 3px 3px 6px rgba(0,0,0,0.2);
     `}
 

--- a/src/components/common/Modal/TimetableModal/WishTimetable.tsx
+++ b/src/components/common/Modal/TimetableModal/WishTimetable.tsx
@@ -143,7 +143,7 @@ const GridContainer = styled.div`
   border-collapse: collapse;
   border: 1.6px solid #000;
   display: grid;
-  grid-template-columns: 100px repeat(5, 1fr);
+  grid-template-columns: 10rem repeat(5, 1fr);
   grid-template-rows: repeat(28, 1fr);
   border: 1px solid #000;
 `;
@@ -155,7 +155,7 @@ const GridHeader = styled.div`
     ${props => props.theme.texts.tableTitle};
     text-align: center;
     font-weight: bold;
-    padding: 10px;
+    padding: 1rem;
     background-color: #f0f0f0;
     border: 1px solid #e5e5e5;
   }
@@ -175,7 +175,7 @@ const Tooltip = styled.div`
   white-space: nowrap;
   pointer-events: none;
   transition: opacity 0.3s ease-in-out;
-  max-width: 300px;
+  max-width: 30rem;
   word-wrap: break-word;
   opacity: 1;
 

--- a/src/components/common/Modal/TimetableModal/index.tsx
+++ b/src/components/common/Modal/TimetableModal/index.tsx
@@ -1,11 +1,17 @@
 import styled from 'styled-components';
-import close from '@assets/img/close-line.png';
 import {useDispatch} from 'react-redux';
 import {closeHandler} from '@components/common/Modal/handlers/handler.tsx';
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import {getWishlist} from '@/apis/api/course';
 import {useAppSelector} from '@/store/hooks';
 import WishTimetable from './WishTimetable';
+import {
+  CloseImage,
+  Modal,
+  ModalContainer,
+  ModalHeader,
+  Title,
+} from '@/styles/ModalLayout';
 
 interface WishlistData {
   curiNm: string | undefined;
@@ -45,8 +51,8 @@ function TimetableModal() {
   };
 
   return (
-    <ModalContainer $isEmpty={isEmpty}>
-      <Modal $isEmpty={isEmpty}>
+    <TimetableModalContainer $isEmpty={isEmpty}>
+      <ModalWrap $isEmpty={isEmpty}>
         <ModalHeader>
           <Title>관심과목 강의 시간표</Title>
           <CloseImage onClick={closeButton} />
@@ -58,41 +64,29 @@ function TimetableModal() {
             <WishTimetable wishlistData={wishlistData} />
           )}
         </ModalBody>
-        <ModalFooter>
+        <FooterWrap>
           <InfoMessage>
             ※ 시간표가 표시되지 않는 경우 잠시 기다리거나 관심과목 강의 시간표
             창을 닫고 새로 열어주세요.
           </InfoMessage>
-          <FooterWrap>
+          <ModalFooter>
             <FooterBtn style={{marginRight: '20px'}} onClick={closeButton}>
               닫기
             </FooterBtn>
-          </FooterWrap>
-        </ModalFooter>
-      </Modal>
-    </ModalContainer>
+          </ModalFooter>
+        </FooterWrap>
+      </ModalWrap>
+    </TimetableModalContainer>
   );
 }
 
-const ModalContainer = styled.div<{$isEmpty: boolean}>`
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0);
-  display: flex;
-  justify-content: center;
-  z-index: 10;
+const TimetableModalContainer = styled(ModalContainer)<{$isEmpty: boolean}>`
   overflow: auto;
   position: ${({$isEmpty}) => ($isEmpty ? 'absolute' : 'fixed')};
   align-items: ${({$isEmpty}) => ($isEmpty ? 'center' : 'flex-start')};
 `;
 
-const Modal = styled.div<{$isEmpty: boolean}>`
-  position: relative;
-  width: 82rem;
-  height: 100%;
-  border: 1px solid #000000;
-  background: #ffffff;
-  font-weight: lighter;
+const ModalWrap = styled(Modal)<{$isEmpty: boolean}>`
   overflow: auto;
   display: flex;
   flex-direction: column;
@@ -100,29 +94,6 @@ const Modal = styled.div<{$isEmpty: boolean}>`
   margin: 3rem;
   width: ${({$isEmpty}) => ($isEmpty ? '60rem' : '82rem')};
   height: ${({$isEmpty}) => ($isEmpty ? '24rem' : '108rem')};
-`;
-
-const ModalHeader = styled.div`
-  display: flex;
-  justify-content: space-between;
-  border-bottom: 1px solid #ababab;
-`;
-
-const Title = styled.div`
-  font-size: 2rem;
-  font-weight: bolder;
-  padding: 15px 30px;
-`;
-
-const CloseImage = styled.img.attrs({
-  src: `${close}`,
-})`
-  display: block;
-  width: 25px;
-  height: 25px;
-  cursor: pointer;
-  margin-top: 10px;
-  margin-right: 10px;
 `;
 
 const ModalBody = styled.div`
@@ -138,7 +109,7 @@ const EmptyContent = styled.div`
   font-size: 1.8rem;
 `;
 
-const ModalFooter = styled.div`
+const FooterWrap = styled.div`
   width: 100%;
   height: auto;
   display: flex;
@@ -151,20 +122,20 @@ const InfoMessage = styled.p`
   margin: 1rem;
 `;
 
-const FooterWrap = styled.div`
+const ModalFooter = styled.div`
   background: ${props => props.theme.colors.neutral5};
   width: 100%;
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  height: 50px;
+  height: 5rem;
 `;
 
 const FooterBtn = styled.div`
   font-size: 1.4rem;
   border: 1px solid #000000;
   background: #ffffff;
-  padding: 6px 15px;
+  padding: 0.6rem 1.5rem;
   cursor: pointer;
 
   &:hover {

--- a/src/components/common/Modal/WaitingModal.tsx
+++ b/src/components/common/Modal/WaitingModal.tsx
@@ -105,11 +105,11 @@ function WaitingModal() {
 const WaitingModalBox = styled(Modal)`
   position: static;
   width: 39rem;
-  height: 43rem;
+  height: 45rem;
   min-width: 39rem;
   min-height: 43rem;
   font-weight: lighter;
-  padding: 2rem 4rem;
+  padding: 1rem 4rem;
   word-break: unset;
   display: flex;
   flex-direction: column;
@@ -119,17 +119,18 @@ const WaitingModalBox = styled(Modal)`
 const Logo = styled.img.attrs({
   src: `${logo}`,
 })`
-  width: 55px;
+  width: 5.5rem;
   margin-right: auto;
   display: block;
-  margin-top: 10px;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
 `;
 
 const Title = styled.p`
   font-size: 2.5rem;
   font-weight: bold;
   color: #676763;
-  margin-bottom: 20px;
+  margin-bottom: 2rem;
 `;
 
 const SubTitle = styled.p`
@@ -141,17 +142,17 @@ const SubTitle = styled.p`
 const ProgressBarContainer = styled.div`
   width: 100%;
   background-color: #e0e0e0;
-  border-radius: 10px;
+  border-radius: 1rem;
   overflow: hidden;
-  margin-top: 10px;
-  margin-bottom: 20px;
+  margin-top: 1rem;
+  margin-bottom: 2rem;
 `;
 
 const ProgressBarFill = styled.div<{$progress: number}>`
-  height: 10px;
+  height: 1rem;
   background-color: #a0a0a0;
   width: ${props => `${props.$progress}%`};
-  border-radius: 10px 0 0 10px;
+  border-radius: 1rem 0 0 1rem;
   transition: width 0.3s ease;
 `;
 
@@ -175,14 +176,14 @@ const StopButton = styled.div`
   text-align: center;
   font-size: 1.5rem;
   border: 1px solid #8d8d87;
-  padding: 8px 13px;
+  padding: 0.8rem 1.3rem;
   color: #676763;
   display: flex;
   justify-content: center;
   align-items: center;
   cursor: pointer;
-  margin-top: 30px;
-  margin-bottom: 10px;
+  margin-top: 2.5rem;
+  margin-bottom: 1rem;
 
   &:hover {
     border: 1px solid #a6a69e;
@@ -193,8 +194,8 @@ const StopButton = styled.div`
 const CloseImage = styled.img.attrs({
   src: `${close}`,
 })`
-  width: 15px;
-  margin-right: 10px;
+  width: 1.5rem;
+  margin-right: 1rem;
 `;
 
 export default WaitingModal;

--- a/src/pages/DeleteAccount.tsx
+++ b/src/pages/DeleteAccount.tsx
@@ -6,7 +6,6 @@ import githubIcon from '@assets/img/github-fill.svg';
 import DeleteAccountForm from '@components/DeleteAccount/DeleteAccountForm.tsx';
 
 function DeleteAccount() {
-
   return (
     <Container>
       <Box>
@@ -20,8 +19,13 @@ function DeleteAccount() {
         <FormWrap>
           <DeleteAccountForm />
           <FaqWrap>[ 장애 문의 ]: tutorialsejong@gmail.com</FaqWrap>
-          <FaqWrap><img src={githubIcon} alt="github"
-                        onClick={() => window.open('https://github.com/tutorial-sejong')} /></FaqWrap>
+          <FaqWrap>
+            <img
+              src={githubIcon}
+              alt='github'
+              onClick={() => window.open('https://github.com/tutorial-sejong')}
+            />
+          </FaqWrap>
         </FormWrap>
       </Box>
     </Container>
@@ -29,70 +33,70 @@ function DeleteAccount() {
 }
 
 const Container = styled.div`
-    background: url(${Bg}) 50% 50% no-repeat;
-    background-size: cover;
-    height: 700px;
-    background-color: #fafafa;
-    width: 100%;
+  background: url(${Bg}) 50% 50% no-repeat;
+  background-size: cover;
+  height: 70rem;
+  background-color: #fafafa;
+  width: 100%;
 `;
 
 const Box = styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 `;
 
 const LogoWrap = styled.div`
-    margin: 3rem 0;
+  margin: 3rem 0;
 
-    > img {
-        width: 150px;
-    }
+  > img {
+    width: 15rem;
+  }
 `;
 
 const TitleWrap = styled.div`
-    color: ${props => props.theme.colors.white};
-    text-align: center;
-    margin-bottom: 2.5rem;
+  color: ${props => props.theme.colors.white};
+  text-align: center;
+  margin-bottom: 2.5rem;
 
-    > p {
-        line-height: 2.5rem;
-        font-weight: 600;
-        font-size: 1.35rem;
-    }
+  > p {
+    line-height: 2.5rem;
+    font-weight: 600;
+    font-size: 1.35rem;
+  }
 
-    > p > em {
-        color: #ffea9b;
-    }
+  > p > em {
+    color: #ffea9b;
+  }
 `;
 
 const Title = styled.h1`
-    font-size: 3.5rem;
-    font-weight: 700;
-    margin-bottom: 2rem;
+  font-size: 3.5rem;
+  font-weight: 700;
+  margin-bottom: 2rem;
 `;
 
 const SubTitle = styled.h2`
-    font-size: 2rem;
-    font-weight: 700;
-    margin-bottom: 2rem;
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 2rem;
 `;
 
 const FormWrap = styled.div`
-    margin-bottom: 2.5rem;
+  margin-bottom: 2.5rem;
 `;
 
 const FaqWrap = styled.div`
-    ${props => props.theme.texts.loginContent};
+  ${props => props.theme.texts.loginContent};
+  text-align: center;
+  color: #fff;
+  > img {
+    width: 3rem;
+    cursor: pointer;
+    display: block;
     text-align: center;
-    color: #fff;
-    > img {
-        width: 30px;
-        cursor: pointer;
-        display: block;
-        text-align: center;
-        margin: 20px auto;
-    }
+    margin: 2rem auto;
+  }
 `;
 
 export default DeleteAccount;

--- a/src/pages/Maintenance.tsx
+++ b/src/pages/Maintenance.tsx
@@ -4,45 +4,49 @@ import logo from '@assets/img/tutorial_sejong_logo.webp';
 const MaintenancePage: React.FC = () => {
   return (
     <Container>
-      <Logo src={logo}/>
+      <Logo src={logo} />
       <Title>사이트 리뉴얼 중입니다!</Title>
       <Message>2024년 8월 7일 16:25 ~ 2024년 8월 8일 23:59</Message>
       <Message>이용에 불편을 드려 죄송합니다.</Message>
-      <Message>문의사항이 있으시면 <ContactLink href="mailto:support@example.com">tutorialsejong@gmail.com</ContactLink>으로 연락
-        주세요.</Message>
+      <Message>
+        문의사항이 있으시면{' '}
+        <ContactLink href='mailto:support@example.com'>
+          tutorialsejong@gmail.com
+        </ContactLink>
+        으로 연락 주세요.
+      </Message>
     </Container>
   );
 };
 
-
 const Container = styled.div`
-    text-align: center;
-    padding: 50px;
-    font-family: 'Arial', sans-serif;
+  text-align: center;
+  padding: 5rem;
+  font-family: 'Arial', sans-serif;
 `;
 
 const Logo = styled.img`
-    width: 300px;
+  width: 30rem;
 `;
 
 const Title = styled.h1`
-    font-size: 3rem;
-    color: #333;
+  font-size: 3rem;
+  color: #333;
 `;
 
 const Message = styled.p`
-    color: #666;
-    margin: 20px auto;
-    font-size: 18px;
+  color: #666;
+  margin: 2rem auto;
+  font-size: 1.8rem;
 `;
 
 const ContactLink = styled.a`
-    color: #0077cc;
-    text-decoration: none;
+  color: #0077cc;
+  text-decoration: none;
 
-    &:hover {
-        text-decoration: underline;
-    }
+  &:hover {
+    text-decoration: underline;
+  }
 `;
 
 export default MaintenancePage;

--- a/src/pages/index/Home.tsx
+++ b/src/pages/index/Home.tsx
@@ -115,12 +115,6 @@ const Box = styled.div`
 const Main = styled.div<{$isOpen: boolean}>`
   width: ${props =>
     props.$isOpen ? 'calc(100% - 23rem)' : 'calc(100% - 2rem)'};
-
-  @media ${props => props.theme.device.mobile} {
-    width: calc(100% - 2rem);
-    position: absolute;
-    left: 2rem;
-  }
 `;
 
 const Article = styled.div`

--- a/src/pages/index/Login.tsx
+++ b/src/pages/index/Login.tsx
@@ -196,7 +196,7 @@ function Login() {
 const Container = styled.div`
   background: url(${Bg}) 50% 50% no-repeat;
   background-size: cover;
-  height: 700px;
+  height: 70rem;
   background-color: #fafafa;
   width: 100%;
 `;
@@ -211,7 +211,7 @@ const LogoWrap = styled.div`
   margin: 3rem 0;
 
   > img {
-    width: 150px;
+    width: 15rem;
   }
 `;
 
@@ -257,20 +257,20 @@ const FaqWrap = styled.div`
   ${props => props.theme.texts.loginContent};
 
   > img {
-    width: 30px;
+    width: 3rem;
     cursor: pointer;
     display: block;
     text-align: center;
-    margin: 20px auto;
+    margin: 2rem auto;
   }
 `;
 
 const TermsContainer = styled.div`
-  max-width: 890px;
-  margin: 0 auto 20px;
-  padding: 20px;
+  max-width: 89rem;
+  margin: 0 auto 2rem;
+  padding: 2rem;
   background-color: #f9f9f9;
-  border-radius: 10px;
+  border-radius: 1rem;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 `;
 
@@ -283,10 +283,10 @@ const CheckboxWrap = styled.div`
 `;
 
 const TermsTitle = styled.h1`
-  font-size: 24px;
+  font-size: 2.4rem;
   font-weight: bold;
   color: #333;
-  margin-bottom: 20px;
+  margin-bottom: 2rem;
 `;
 
 const List = styled.ul`
@@ -296,15 +296,15 @@ const List = styled.ul`
 `;
 
 const ListTitle = styled.li`
-  font-size: 18px;
+  font-size: 1.8rem;
   font-weight: bold;
-  margin-top: 15px;
-  margin-bottom: 15px;
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
 `;
 
 const ListItem = styled.li`
-  margin-bottom: 5px;
-  font-size: 15px;
+  margin-bottom: 0.5rem;
+  font-size: 1.5rem;
   color: #555;
   line-height: 2.5rem;
 

--- a/src/styles/ModalLayout.tsx
+++ b/src/styles/ModalLayout.tsx
@@ -43,6 +43,7 @@ export const CloseImage = styled.img.attrs({
   cursor: pointer;
   margin-top: 1rem;
   margin-right: 1rem;
+  margin-left: auto;
 `;
 
 export const ModalBody = styled.div`


### PR DESCRIPTION
## Issue
- [TS-56](https://jeez.atlassian.net/browse/TS-56?atlOrigin=eyJpIjoiYmQxOTQwZDEzODQxNDFjMWEyZjg3YTNiOGNkOTAxYjciLCJwIjoiaiJ9)
## Details
- 수강신청 안내문의 일정을 새로 나온 일정대로 업데이트 했습니다.
    ![스크린샷 2025-01-24 172351](https://github.com/user-attachments/assets/9cedd3e7-2277-43ba-b7b5-5695efc6756b)

- 모든 컴포넌트의 단위를 px에서 rem으로 통일했습니다.
- 레이아웃이 깨지는 모달들의 스타일을 수정했습니다.
- 화면이 작을 때 메뉴바가 겹치는 문제를 해결했습니다.
    - 수정 전
        ![스크린샷 2025-01-24 171819](https://github.com/user-attachments/assets/4f3fc222-e0f1-42a5-a664-5607e24fb20f)
    - 수정 후
        ![스크린샷 2025-01-24 172000](https://github.com/user-attachments/assets/91a9474e-1de5-4366-a107-cea4d27fe65e)

- 수강신청 테이블에서 과목명이 길어서 칸을 넘어가는 경우의 스타일을 수정했습니다.
    - 수정 전
        ![스크린샷 2025-01-24 172821](https://github.com/user-attachments/assets/9741f323-e34b-4db4-8a8d-440fdd6b4dc3)
    - 수정 후
    - 과목명을 말줄임표('...')으로 줄이고 마우스를 올리면 과목명 전체를 볼 수 있게 했습니다.
        ![스크린샷 2025-01-24 193828](https://github.com/user-attachments/assets/f1d47a73-a7ec-4a18-8342-bb54ee8a6a3a)



[TS-56]: https://jeez.atlassian.net/browse/TS-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ